### PR TITLE
Interleave bitvec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fmlrc"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["holtjma <jholt@hudsonalpha.org>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -81,12 +81,12 @@ The actual corrections are _nearly_ identical (there are slight differences not 
 However, FMLRC v2 runs in less than half the time from both real time and CPU time perspectives. 
 While not explicitly measured, FMLRC v2 does use ~1GB of extra memory due to the 10-mer cache (`-C 10`).
 
-| Metric | FMLRC v1.0.0 | FMLRC2 v0.1.3 (`-C 10`) |
+| Metric | FMLRC v1.0.0 | FMLRC2 v0.1.4 (`-C 10`) |
 | - | - | - |
 | Recall | 0.9825 | 0.9826 |
 | Precision | 0.9815 | 0.9816 |
-| Real time | 7m29.908s | **3m0.885s** |
-| CPU time | 51m34.704s | **20m35.792s** |
+| Real time | 7m29.908s | **2m57.711s** |
+| CPU time | 51m34.704s | **19m12.348s** |
 
 ## Reference
 FMLRC v2 does not currently have a pre-print or paper. If you use FMLRC v2, please cite the FMLRC v1 paper:


### PR DESCRIPTION
This change interleaves the vector used for storing bits and the vector used for storing rank blocks.  Functionally identical, but faster because the two pieces of information required at each rank step are co-located in memory (aka reducing page-ins). 